### PR TITLE
STYLE: Let NO_FILESYSTEM_ACCESS/TransformIO use itkGenericExceptionMacro

### DIFF
--- a/Common/Transforms/elxTransformIO.cxx
+++ b/Common/Transforms/elxTransformIO.cxx
@@ -195,9 +195,7 @@ void
 elastix::TransformIO::Write(const itk::Object & itkTransform, const std::string & fileName)
 {
 #ifdef ELX_NO_FILESYSTEM_ACCESS
-  const std::string message = "File IO not supported in WebAssembly builds.";
-  log::error(message);
-  throw std::runtime_error(message);
+  itkGenericExceptionMacro("File IO not supported in WebAssembly builds.");
 #else
   try
   {
@@ -219,10 +217,7 @@ itk::SmartPointer<itk::TransformBase>
 elastix::TransformIO::Read(const std::string & fileName)
 {
 #ifdef ELX_NO_FILESYSTEM_ACCESS
-  const std::string message = "File IO not supported in WebAssembly builds.";
-  log::error(message);
-  throw std::runtime_error(message);
-  return nullptr;
+  itkGenericExceptionMacro("File IO not supported in WebAssembly builds.");
 #else
 
   const auto reader = itk::TransformFileReader::New();


### PR DESCRIPTION
Instead of log::error and std::runtime_error. Aims to simplify the code.